### PR TITLE
Stopped msgDialogs from flickering.

### DIFF
--- a/source/util.c
+++ b/source/util.c
@@ -96,7 +96,7 @@ int fps_update ()
 
 void do_flip ()
 {
-    sysUtilCheckCallback ();
+    //sysUtilCheckCallback ();
     flip ();
     tiny3d_Flip ();
 }


### PR DESCRIPTION
By removing ```sysUtilCheckCallback()``` in ```do_flip()```, the msgDialog screens no longer flicker, and behave normally.